### PR TITLE
Add Apple High Efficiency Image File Format image extensions

### DIFF
--- a/image-extensions.json
+++ b/image-extensions.json
@@ -118,5 +118,7 @@
 	"sid",
 	"ras",
 	"sun",
-	"tga"
+	"tga",
+	"heic",
+	"heif"
 ]


### PR DESCRIPTION
Adding support to the .heic and .heif file extensions. For more details about those formats being used by Apple, please check https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format

This PR acceptance will also help the is-image package to properly identify those as image files.